### PR TITLE
Change required Python version from 3.12 to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "playlet-clip"
 version = "2.0.0"
 description = "AI-powered short drama auto-editing tool with ASR, TTS and Gradio UI"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [
     { name = "anning", email = "anningforchina@gmail.com" }


### PR DESCRIPTION
Resolve:
```bash
#13 [ 8/10] RUN uv pip install --system -e .
#13 0.253 Using Python 3.10.14 environment at: /opt/conda
#13 0.268   × No solution found when resolving dependencies:
#13 0.268   ╰─▶ Because the current Python version (3.10.14) does not satisfy
#13 0.268       Python>=3.12 and playlet-clip==2.0.0 depends on Python>=3.12, we can
#13 0.268       conclude that playlet-clip==2.0.0 cannot be used.
#13 0.268       And because only playlet-clip==2.0.0 is available and you require
#13 0.268       playlet-clip, we can conclude that your requirements are unsatisfiable.
#13 ERROR: process "/bin/sh -c uv pip install --system -e ." did not complete successfully: exit code: 1
------
 > [ 8/10] RUN uv pip install --system -e .:
0.253 Using Python 3.10.14 environment at: /opt/conda
0.268   × No solution found when resolving dependencies:
0.268   ╰─▶ Because the current Python version (3.10.14) does not satisfy
0.268       Python>=3.12 and playlet-clip==2.0.0 depends on Python>=3.12, we can
0.268       conclude that playlet-clip==2.0.0 cannot be used.
0.268       And because only playlet-clip==2.0.0 is available and you require
[+] up 0/1  playlet-clip, we can conclude that your requirements are unsatisfiable.
 - Image playlet-clip:latest Building                                                                          702.0s
Dockerfile:35

--------------------

  33 |

  34 |     # Install dependencies

  35 | >>> RUN uv pip install --system -e .

  36 |

  37 |     # Create directories

--------------------

failed to solve: process "/bin/sh -c uv pip install --system -e ." did not complete successfully: exit code: 1
```