### PR TITLE
fix(docker): support Blackwell gpu architecture

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime
+FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
 
 LABEL maintainer="anning <anningforchina@gmail.com>"
 LABEL description="Playlet-Clip: AI-powered short drama auto-editing tool"
@@ -47,7 +47,10 @@ EXPOSE 7860
 # To use CosyVoice, set PLAYLET__TTS__BACKEND=cosyvoice_local and mount the model
 ENV PLAYLET__UI_HOST=0.0.0.0 \
     PLAYLET__UI_PORT=7860 \
+    PLAYLET__ASR__DEVICE=cuda \
     PLAYLET__TTS__BACKEND=edge_tts \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
     PLAYLET__PATHS__INPUT_DIR=/app/data/input \
     PLAYLET__PATHS__OUTPUT_DIR=/app/data/output \
     PLAYLET__PATHS__TEMP_DIR=/app/data/temp \

--- a/docker/docker-compose.cpu.yml
+++ b/docker/docker-compose.cpu.yml
@@ -24,6 +24,7 @@ services:
       # Force CPU mode
       - PLAYLET__ASR__DEVICE=cpu
       - PLAYLET__TTS__DEVICE=cpu
+      - MODELSCOPE_CACHE=/app/models/modelscope
       # Application settings
       - PLAYLET__DEBUG=${DEBUG:-false}
       - PLAYLET__UI_SHARE=${UI_SHARE:-false}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       # TTS configuration - use CosyVoice API
       - TTS_BACKEND=${TTS_BACKEND:-auto}
       - TTS_COSYVOICE_API_URL=http://cosyvoice:8080
+      # GPU deployment
+      - PLAYLET__ASR__DEVICE=${ASR_DEVICE:-cuda}
+      - MODELSCOPE_CACHE=/app/models/modelscope
       # Application settings
       - PLAYLET__DEBUG=${DEBUG:-false}
       - PLAYLET__UI_SHARE=${UI_SHARE:-false}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
     "modelscope>=1.10",
 
     # TTS - CosyVoice dependencies (optional, install from source)
-    "torch>=2.0",
-    "torchaudio>=2.0",
+    "torch>=2.4",
+    "torchaudio>=2.4",
     "transformers>=4.35",
     "onnxruntime>=1.16",
 


### PR DESCRIPTION
Resolve:
```
ERROR    | playlet_clip.core.pipeline:process:204 - Pipeline failed: Failed to load ASR model: CUDA error: no kernel image is available for execution on the device 13.7MB/s] 2.89B/s]

... err stack ...

RuntimeError: CUDA error: no kernel image is available for execution on the device
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
```

> GPU: RTX5080